### PR TITLE
fix: log startup banner to stderr instead of stdout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.log("Aceternity UI MCP server is running...");
+  console.error("Aceternity UI MCP server is running...");
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary

- Switch the startup banner from `console.log` to `console.error` in `src/index.ts` so it goes to stderr instead of stdout.

## Why

MCP's stdio transport reserves **stdout exclusively for JSON-RPC frames**. The line

\`\`\`ts
console.log(\"Aceternity UI MCP server is running...\");
\`\`\`

writes plain text to stdout, which corrupts the client's JSON-RPC parser. In Claude Desktop's MCP log every session opens with:

\`\`\`
[error] Unexpected token 'A', \"Aceternity\"... is not valid JSON
    at JSON.parse (<anonymous>)
    at ... readMessage ...
\`\`\`

The next valid JSON-RPC message (the \`initialize\` response) is still consumed correctly, so tools keep working — but every startup logs the error. \`console.error\` routes the banner to stderr (the convention used in the official MCP SDK examples), keeping stdout clean for the protocol.

## Test plan

- [x] Local build with the change
- [ ] Run via \`npx\` in Claude Desktop and confirm the \`Unexpected token 'A'\` line no longer appears in the MCP log
- [ ] Confirm \`tools/list\` still returns all 5 tools and they remain callable